### PR TITLE
코드리뷰 대상 프로젝트 경로를 지정하여 리뷰

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -36,9 +36,15 @@ ENDPOINT="http://localhost:11434/api/chat"
 RESPONSE_PATH=".message.content"
 
 MAX_TOKENS=4096
+
 # File extensions to be reviewed
 # Merged file extensions for review
 FILE_EXTENSIONS=".json$|.xml$|.ts$|.js$|.html$|.vue$|.sh$|.tsx$|.jsx$|.py$|.css$"
+
+# Target Project Settings
+TARGET_PROJECT_PATH=""
+
+# Prompt
 PROMPT="
 <역할>
 당신은 코드 리뷰어입니다. 당신은 증거와 논리에 기반하여 피드백을 제공합니다.


### PR DESCRIPTION
현재 저장소를 대상으로 코드리브를 수행할 수밖에 없는 현재 상황을 개선하기 위한 PR 입니다.

관련 이슈 : #1 

- `.env` 에 TARGET_OBJECT_PATH 추가.
- TARGET_OBJECT_PATH 를 참조해 해당 경로로 이동하여 코드리뷰를 수행하도록 함.
- 코드리뷰 수행 후 현 디렉토리로 복귀하도록 함.
- 단계별 참고용 메시지 출력 추가함.
- 코드리뷰 대상이 없을 때 메시지 출력 후 중단되도록 함.

close #1